### PR TITLE
Refactor Ficon::new use `&` instead of `as_str()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,9 @@ impl Ficon {
         }?;
 
         let config = fs::read_to_string(&config_path)
-            .with_context(|_| format!("Config file is missing: {}", config_path.as_str()))?;
+            .with_context(|_| format!("Config file is missing: {}", &config_path))?;
 
-        let config: Config = toml::from_str(config.as_str())
+        let config: Config = toml::from_str(&config)
             .with_context(|_| "Error while parsing configuration file")?;
 
         Ok(Ficon { option, config })


### PR DESCRIPTION
We can pass `&` of type `String` to function that need `&str` not need to convert by `as_str()`.